### PR TITLE
Fix 2-days long but < 24h events

### DIFF
--- a/src/View/Helper/CalendarHelper.php
+++ b/src/View/Helper/CalendarHelper.php
@@ -92,7 +92,7 @@ class CalendarHelper extends Helper {
 		$days = [
 		];
 		$count = 0;
-		while ($from < $to) {
+		while ($from <= $to) {
 			if ($from->month === $month) {
 				$days[$count] = $this->retrieveDayFromDate($from);
 			}


### PR DESCRIPTION
Fix #13 where events not showing up on the second day if two days long but equal or less than 24 hours.