### PR TITLE
Fix GoogleCalendarHelper malformed Google Calendar URLs

### DIFF
--- a/src/View/Helper/GoogleCalendarHelper.php
+++ b/src/View/Helper/GoogleCalendarHelper.php
@@ -48,10 +48,9 @@ class GoogleCalendarHelper extends Helper {
 			/** @var \Cake\I18n\DateTime|\Cake\I18n\Date|string $from */
 			$from = $dateFromTo['from'];
 			if ($from instanceof Date) {
-				$from = $from->year . $from->month . $from->day;
+				$from = $from->format('Ymd');
 			} elseif (!is_string($from)) {
-				$from = $from->toIso8601String();
-				$from = str_replace('-', '', $from);
+				$from = $from->setTimezone('UTC')->format('Ymd\THis\Z');
 			}
 			$dates[] = $from;
 		}
@@ -59,16 +58,14 @@ class GoogleCalendarHelper extends Helper {
 			/** @var \Cake\I18n\DateTime|\Cake\I18n\Date|string $to */
 			$to = $dateFromTo['to'];
 			if ($to instanceof Date) {
-				$to = $to->year . $to->month . $to->day;
+				$to = $to->format('Ymd');
 			} elseif (!is_string($to)) {
-				$to = $to->toIso8601String();
-				$to = str_replace('-', '', $to);
+				$to = $to->setTimezone('UTC')->format('Ymd\THis\Z');
 			}
 			$dates[] = $to;
 		} elseif (!empty($dateFromTo['from']) && $dateFromTo['from'] instanceof Date) {
 			$to = $dateFromTo['from']->addDays(1);
-			$dates[] = $to->year . $to->month . $to->day;
-
+			$dates[] = $to->format('Ymd');
 		}
 
 		if (!$dates) {

--- a/tests/TestCase/View/Helper/GoogleCalendarHelperTest.php
+++ b/tests/TestCase/View/Helper/GoogleCalendarHelperTest.php
@@ -52,7 +52,7 @@ class GoogleCalendarHelperTest extends TestCase {
 		];
 
 		$result = $this->GoogleCalendar->url('My title', $fromTo, $details);
-		$expected = 'https://calendar.google.com/calendar/render?action=TEMPLATE&text=My+title&dates=20231202T15%3A00%3A00%2B00%3A00%2F20231202T18%3A00%3A00%2B00%3A00&details=My+details&location=My+location';
+		$expected = 'https://calendar.google.com/calendar/render?action=TEMPLATE&text=My+title&dates=20231202T150000Z%2F20231202T180000Z&details=My+details&location=My+location';
 		$this->assertSame($expected, $result);
 	}
 
@@ -65,7 +65,7 @@ class GoogleCalendarHelperTest extends TestCase {
 		];
 
 		$result = $this->GoogleCalendar->url('My title', $fromTo);
-		$expected = 'https://calendar.google.com/calendar/render?action=TEMPLATE&text=My+title&dates=2023122%2F2023123';
+		$expected = 'https://calendar.google.com/calendar/render?action=TEMPLATE&text=My+title&dates=20231202%2F20231203';
 		$this->assertSame($expected, $result);
 	}
 
@@ -78,7 +78,7 @@ class GoogleCalendarHelperTest extends TestCase {
 		];
 
 		$result = $this->GoogleCalendar->link('My title', $fromTo);
-		$expected = '<a href="https://calendar.google.com/calendar/render?action=TEMPLATE&amp;text=My+title&amp;dates=2023122%2F2023123">My title</a>';
+		$expected = '<a href="https://calendar.google.com/calendar/render?action=TEMPLATE&amp;text=My+title&amp;dates=20231202%2F20231203">My title</a>';
 		$this->assertSame($expected, $result);
 	}
 


### PR DESCRIPTION
## Summary

`GoogleCalendarHelper::url()` produced malformed `dates=` query parameters on the Google Calendar render endpoint:

- For `Cake\I18n\Date`, the date was built via property concatenation (`$from->year . $from->month . $from->day`) which skips zero-padding. `2023-12-02` became `2023122` instead of `20231202`, breaking the URL Google expects.
- For `Cake\I18n\DateTime`, only dashes were stripped from `toIso8601String()`, leaving colons and the `+00:00` offset (e.g. `20231202T15:00:00+00:00`). Google's documented format is `YYYYMMDDTHHmmssZ` in UTC.

The fix:

- Date branch now uses `format('Ymd')` so single-digit months/days are zero-padded.
- DateTime branch now converts to UTC via `setTimezone('UTC')` and formats with `Ymd\THis\Z`.
- The `addDays(1)` fallback for `Date` (when only `from` is supplied) also uses `format('Ymd')`.

The three test assertions in `GoogleCalendarHelperTest.php` previously asserted the buggy output (`2023122%2F2023123` and the colon/offset string), so they're updated in the same patch to the corrected URL format.

## Verification

- phpunit: 15 tests, 31 assertions — all green
- phpstan: no errors
- phpcs (src/, modified test): clean