### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/calendar.pot
+++ b/resources/locales/calendar.pot
@@ -1,0 +1,22 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 02:45+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "previous"
+msgstr ""
+
+msgid "next"
+msgstr ""
+

--- a/src/View/Helper/CalendarHelper.php
+++ b/src/View/Helper/CalendarHelper.php
@@ -157,7 +157,7 @@ class CalendarHelper extends Helper {
 			$suffix = $this->getConfig('multiLabelSuffix');
 		}
 		foreach ($days as $i => $day) {
-			$suffixTranslated = __($suffix, $i + 1);
+			$suffixTranslated = __d('calendar', $suffix, $i + 1);
 			$this->dataContainer[$day][] = $this->Html->tag('li', $content . $suffixTranslated, $options);
 		}
 	}
@@ -362,7 +362,7 @@ class CalendarHelper extends Helper {
 			$url = array_merge($url, $viewVars['url']);
 		}
 
-		return $this->Html->link(__('previous'), $url);
+		return $this->Html->link(__d('calendar', 'previous'), $url);
 	}
 
 	/**
@@ -415,7 +415,7 @@ class CalendarHelper extends Helper {
 			$url = array_merge($url, $viewVars['url']);
 		}
 
-		return $this->Html->link(__('next'), $url);
+		return $this->Html->link(__d('calendar', 'next'), $url);
 	}
 
 	/**
@@ -453,7 +453,7 @@ class CalendarHelper extends Helper {
 			return null;
 		}
 
-		return __(ucfirst($this->monthList[$month - 1]));
+		return __d('calendar', ucfirst($this->monthList[$month - 1]));
 	}
 
 }


### PR DESCRIPTION
## Summary

- Convert 4 `__()` calls in `CalendarHelper` to `__d('calendar', ...)` so plugin strings live in their own domain.
- Add `resources/locales/calendar.pot` (2 unique static msgids — `previous` and `next`) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT. The other two calls take dynamic arguments (a configured suffix and the localized month list) and cannot be extracted statically; translators populate those entries by hand from the configured labels.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 15 / 15
- phpstan: no errors
- phpcs: clean