### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Utility/IcalFormatter.php
+++ b/src/Utility/IcalFormatter.php
@@ -109,7 +109,7 @@ class IcalFormatter {
 		$lines[] = 'DTSTAMP:' . static::formatDateTime(new DateTimeImmutable('now', new DateTimeZone('UTC')));
 		$lines[] = static::formatDateTimeProperty('DTSTART', $start, $allDay);
 
-		if ($end instanceof \DateTimeImmutable) {
+		if ($end instanceof DateTimeImmutable) {
 			$lines[] = static::formatDateTimeProperty('DTEND', $end, $allDay);
 		}
 		if (isset($event['created'])) {

--- a/src/Utility/IcalFormatter.php
+++ b/src/Utility/IcalFormatter.php
@@ -65,10 +65,10 @@ class IcalFormatter {
 			'BEGIN:VCALENDAR',
 			'VERSION:2.0',
 			'PRODID:' . static::escape((string)$options['prodid']),
-			'CALSCALE:' . (string)$options['calscale'],
+			'CALSCALE:' . $options['calscale'],
 		];
 		if ($options['method'] !== null) {
-			$lines[] = 'METHOD:' . (string)$options['method'];
+			$lines[] = 'METHOD:' . $options['method'];
 		}
 
 		foreach ($events as $event) {
@@ -109,7 +109,7 @@ class IcalFormatter {
 		$lines[] = 'DTSTAMP:' . static::formatDateTime(new DateTimeImmutable('now', new DateTimeZone('UTC')));
 		$lines[] = static::formatDateTimeProperty('DTSTART', $start, $allDay);
 
-		if ($end !== null) {
+		if ($end instanceof \DateTimeImmutable) {
 			$lines[] = static::formatDateTimeProperty('DTEND', $end, $allDay);
 		}
 		if (isset($event['created'])) {
@@ -128,7 +128,7 @@ class IcalFormatter {
 			$lines[] = 'LOCATION:' . static::escape((string)$event['location']);
 		}
 		if (isset($event['url']) && $event['url'] !== '') {
-			$lines[] = 'URL:' . (string)$event['url'];
+			$lines[] = 'URL:' . $event['url'];
 		}
 		if (isset($event['categories']) && $event['categories'] !== []) {
 			$categories = is_array($event['categories']) ? $event['categories'] : [$event['categories']];

--- a/src/View/Helper/CalendarHelper.php
+++ b/src/View/Helper/CalendarHelper.php
@@ -102,7 +102,7 @@ class CalendarHelper extends Helper {
 				->addDays($modifier)
 				->i18nFormat('c', null, 'en-US');
 
-			if ($intlCalendar->getDayOfWeekType($intlCalendarDayOfWeek) == IntlCalendar::DOW_TYPE_WEEKEND) {
+			if ($intlCalendar->getDayOfWeekType($intlCalendarDayOfWeek) === IntlCalendar::DOW_TYPE_WEEKEND) {
 				$this->weekendDayIndexes[] = $modifier;
 			}
 		}
@@ -257,9 +257,7 @@ class CalendarHelper extends Helper {
 
 		$str .= '</tbody>';
 
-		$str .= '</table>';
-
-		return $str;
+		return $str . '</table>';
 	}
 
 	/**
@@ -380,7 +378,7 @@ class CalendarHelper extends Helper {
 			$year = $currentYear;
 			$month = $currentMonth;
 		}
-		if ($month > 0 && $month < 13 && (int)$year != 0) {
+		if ($month > 0 && $month < 13 && (int)$year !== 0) {
 			$flag = 1;
 		}
 		if ($flag === 0) {

--- a/src/View/Helper/GoogleCalendarHelper.php
+++ b/src/View/Helper/GoogleCalendarHelper.php
@@ -74,13 +74,13 @@ class GoogleCalendarHelper extends Helper {
 		$query[] = 'dates=' . urlencode(implode('/', $dates));
 
 		if (!empty($details['details'])) {
-			$query[] = 'details=' . urlencode($details['details']);
+			$query[] = 'details=' . urlencode((string) $details['details']);
 		}
 		if (!empty($details['location'])) {
-			$query[] = 'location=' . urlencode($details['location']);
+			$query[] = 'location=' . urlencode((string) $details['location']);
 		}
 		if (!empty($details['ctz'])) {
-			$query[] = 'ctz=' . urlencode($details['ctz']);
+			$query[] = 'ctz=' . urlencode((string) $details['ctz']);
 		}
 
 		//TODO: sprop etc

--- a/src/View/Helper/GoogleCalendarHelper.php
+++ b/src/View/Helper/GoogleCalendarHelper.php
@@ -74,13 +74,13 @@ class GoogleCalendarHelper extends Helper {
 		$query[] = 'dates=' . urlencode(implode('/', $dates));
 
 		if (!empty($details['details'])) {
-			$query[] = 'details=' . urlencode((string) $details['details']);
+			$query[] = 'details=' . urlencode((string)$details['details']);
 		}
 		if (!empty($details['location'])) {
-			$query[] = 'location=' . urlencode((string) $details['location']);
+			$query[] = 'location=' . urlencode((string)$details['location']);
 		}
 		if (!empty($details['ctz'])) {
-			$query[] = 'ctz=' . urlencode((string) $details['ctz']);
+			$query[] = 'ctz=' . urlencode((string)$details['ctz']);
 		}
 
 		//TODO: sprop etc

--- a/src/View/Helper/GoogleCalendarHelper.php
+++ b/src/View/Helper/GoogleCalendarHelper.php
@@ -74,13 +74,13 @@ class GoogleCalendarHelper extends Helper {
 		$query[] = 'dates=' . urlencode(implode('/', $dates));
 
 		if (!empty($details['details'])) {
-			$query[] = 'details=' . urlencode((string)$details['details']);
+			$query[] = 'details=' . urlencode($details['details']);
 		}
 		if (!empty($details['location'])) {
-			$query[] = 'location=' . urlencode((string)$details['location']);
+			$query[] = 'location=' . urlencode($details['location']);
 		}
 		if (!empty($details['ctz'])) {
-			$query[] = 'ctz=' . urlencode((string)$details['ctz']);
+			$query[] = 'ctz=' . urlencode($details['ctz']);
 		}
 
 		//TODO: sprop etc

--- a/src/View/IcalView.php
+++ b/src/View/IcalView.php
@@ -37,7 +37,7 @@ class IcalView extends View {
 		?EventManager $eventManager = null,
 		array $viewOptions = [],
 	) {
-		if ($response instanceof \Cake\Http\Response) {
+		if ($response instanceof Response) {
 			$response = $response->withType('ics');
 		}
 

--- a/src/View/IcalView.php
+++ b/src/View/IcalView.php
@@ -37,7 +37,7 @@ class IcalView extends View {
 		?EventManager $eventManager = null,
 		array $viewOptions = [],
 	) {
-		if ($response !== null) {
+		if ($response instanceof \Cake\Http\Response) {
 			$response = $response->withType('ics');
 		}
 

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -21,7 +21,7 @@ foreach ($iterator as $file) {
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
 
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.